### PR TITLE
增加每日课程订阅、新成绩订阅功能，增加新的配置项，修改部分细节代码

### DIFF
--- a/app/helper/mail.py
+++ b/app/helper/mail.py
@@ -3,15 +3,37 @@ from .. import mail
 from flask import current_app, render_template
 from ..decorators import async
 
-@async
-def send_async_email(app, msg):
-    with app.app_context():
-        mail.send(msg)
 
-def send_email(to, subject, template, **kwargs):
-    app = current_app._get_current_object()
-    msg = Message(app.config['FLASKY_MAIL_SUBJECT_PREFIX'] + ' ' + subject,
-                  sender=app.config['FLASKY_MAIL_SENDER'], recipients=[to])
+# @async
+# def send_async_email(app, msg):
+#     with app.app_context():
+#         rsp = mail.send(msg)
+
+
+def send_email(msg):
+    from manage import celery
+
+    @celery.task
+    def send_async_email(msg):
+        # 在make_celery中已经配置过flask上下文了，所以不需要app.app_context
+        rsp = mail.send(msg)
+        current_app.logger.info("send email: " + str(rsp))
+
+    send_async_email(msg)
+
+
+def send_email_by_suggestion(template, **kwargs):
+    msg = Message(current_app.config['FLASKY_MAIL_SUBJECT_PREFIX'] + ' New suggestion',
+                  sender=current_app.config['FLASKY_MAIL_SENDER'], recipients=[current_app.config['SEND_MAIL_TO']])
     msg.body = render_template(template + '.txt', **kwargs)
     msg.html = render_template(template + '.html', **kwargs)
-    send_async_email(app, msg)
+
+    send_email(msg)
+
+
+def send_email_by_error(error_msg):
+    msg = Message(current_app.config['FLASKY_MAIL_SUBJECT_PREFIX'] + ' An error occurred',
+                  sender=current_app.config['FLASKY_MAIL_SENDER'], recipients=[current_app.config['SEND_MAIL_TO']])
+    msg.body = error_msg
+
+    send_email(msg)

--- a/app/helper/views.py
+++ b/app/helper/views.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 import json
 import re
 import requests
@@ -23,7 +24,6 @@ def jw_login():
 
     if form.validate_on_submit():
         site_choose = form.site.data
-        ###
         data = {
             'userName': form.number.data,
             'password': form.password.data
@@ -32,35 +32,27 @@ def jw_login():
         user = User.query.filter_by(user_number=form.number.data).first()
         if user is None:
             new_user = User()
-            new_user.user_number=form.number.data
+            new_user.user_number = form.number.data
             db.session.add(new_user)
             db.session.commit()
             user = User.query.filter_by(user_number=form.number.data).first()
 
-        # user.create_spd()
-        user.spd=jw_spider()
+        user.spd = jw_spider()
         user.spd.site = int(site_choose)
-        # user.spd.set_age(int(form.number.data[0:2]))
-        # user.test_id = 1
         user.spd.age = int(form.number.data[0:2])
         login_res = user.spd.login(login_data=data)
         if login_res == 'success':
             login_user(user)
-            # return redirect(url_for('helper.get_grade_start', num=user.user_number))
-            # if request.args.get('next'):
-            #     next = url_for('main.index')+request.args.get('next')
-            #     print(next)
-
             return redirect(request.args.get('next') or url_for('helper.get_grade_start'))
         else:
             flash(login_res)
-    return render_template('helper/login.html',form=form)
+    return render_template('helper/login.html', form=form)
+
 
 @helper.route('/grade')
 @jw_login_required
 def get_grade_start():
-    return redirect(url_for('helper.get_grade',term=1))
-
+    return redirect(url_for('helper.get_grade', term=1))
 
 
 @helper.route('/grades/<int:term>', methods=['GET', 'POST'])
@@ -72,8 +64,10 @@ def get_grade(term):
     except:
         grade_res = [['null', 'null', 0, 0]]
     # cnt = len(grade_res)
-    total_term = (16 - current_user.spd.age) * 2 + 1
-    return render_template('helper/grade.html', grades = grade_res, terms=total_term, term_now = term, base_url = current_user.spd.base_url)
+    cur_year = datetime.datetime.now().year % 2000
+    total_term = (cur_year - current_user.spd.age) * 2 - 1
+    return render_template('helper/grade.html', grades=grade_res, terms=total_term, term_now=term, base_url=current_user.spd.base_url)
+
 
 @helper.route('/jw_logout')
 # @login_required
@@ -88,28 +82,29 @@ def jw_logout():
 def calculate():
     # print('?')
     res = request.form.getlist('g')
-    total_weight=0
-    total_grade=0
+    total_weight = 0
+    total_grade = 0
     for r in res:
         weight = int(re.sub(r',\d+', '', r))
         grade = int(re.sub(r'\d+,', '', r))
-        total_grade += weight*grade
+        total_grade += weight * grade
         total_weight += weight
     # print(res[0])
     if(total_weight != 0):
-        gpa = total_grade/total_weight/20
+        gpa = total_grade / total_weight / 20
         gpa = str('%.3f' % gpa)
         # print(gpa)
     else:
         gpa = 'wrong!'
     return gpa
 
+
 @helper.route('/_cal2', methods=['GET', 'POST'])
 def calculate_std():
     # print('?')
     res = request.form.getlist('g')
-    total_weight=0
-    total_grade=0
+    total_weight = 0
+    total_grade = 0
     for r in res:
         weight = int(re.sub(r',\d+', '', r))
         grade = int(re.sub(r'\d+,', '', r))
@@ -125,7 +120,7 @@ def calculate_std():
         total_weight += weight
     # print(res[0])
     if(total_weight != 0):
-        gpa = total_grade/total_weight
+        gpa = total_grade / total_weight
         gpa = str('%.3f' % gpa)
         # print(gpa)
     else:
@@ -138,13 +133,14 @@ def calculate_std():
 def grade_cal():
     total_term = (16 - current_user.spd.age) * 2 + 1
     grades = []
-    for i in range(1,total_term+1):
+    for i in range(1, total_term + 1):
         temp_grade = current_user.spd.get_grade(age=current_user.spd.age, term=i)
         grades.append(temp_grade)
         # for ls in temp_grade:
         #     grades.append(ls)
 
-    return render_template('helper/cal.html', grades = grades)
+    return render_template('helper/cal.html', grades=grades)
+
 
 @helper.route('/wechat/grade')
 def get_wechat_grade_start():
@@ -152,7 +148,7 @@ def get_wechat_grade_start():
     openid = request.args.get('openid')
     if not openid:
         current_app.logger.info('test1')
-        return redirect(url_for('helper.get_grade',term=1))
+        return redirect(url_for('helper.get_grade', term=1))
     else:
         user = User.query.filter_by(wechat_id=openid).first()
         # current_app.logger.info(user.password)
@@ -171,8 +167,8 @@ def get_wechat_grade_start():
             'userName': user.user_number,
             'password': pwd
         }
-        current_app.logger.info('username=%s'%data.get('userName'))
-        current_app.logger.info('password=%s'%data.get('password'))
+        current_app.logger.info('username=%s' % data.get('userName'))
+        current_app.logger.info('password=%s' % data.get('password'))
         user.spd = jw_spider()
         user.spd.site = 0
         user.spd.age = int(user.user_number[0:2])
@@ -198,7 +194,7 @@ def get_wechat_grade_start():
 @helper.route('/wechat/jw_login', methods=['GET', 'POST'])
 def jw_wechat_login(type=0):
     form = wechat_JWLoginForm()
-    if type==1:
+    if type == 1:
         flash('您绑定的账号密码有误，请重新绑定！')
     if form.validate_on_submit():
         openid = request.args.get('openid')
@@ -217,16 +213,17 @@ def jw_wechat_login(type=0):
 
         # user.create_spd()
         if form.rem_wechat.data == True:
-            #加密账号密码并储存
+            # 加密账号密码并储存
             user.remember_me = True
             user.user_number = form.number.data
             cipher = AESCipher(current_app.config['PASSWORD_SECRET_KEY'])
+            print("form.password.data", form.password.data)
             pwd = cipher.encrypt(form.password.data)
             user.password = pwd
             db.session.add(user)
             current_app.logger.info('chucunlema')
             db.session.commit()
-        user.spd=jw_spider()
+        user.spd = jw_spider()
         user.spd.site = int(site_choose)
         # user.spd.set_age(int(form.number.data[0:2]))
         # user.test_id = 1
@@ -250,7 +247,7 @@ def get_wechat_cal_start():
     openid = request.args.get('openid')
     if not openid:
         current_app.logger.info('test1')
-        return redirect(url_for('helper.grade_cal',term=1))
+        return redirect(url_for('helper.grade_cal', term=1))
     else:
         user = User.query.filter_by(wechat_id=openid).first()
         if user is None or user.wechat_id is None:
@@ -263,7 +260,6 @@ def get_wechat_cal_start():
         except:
             current_app.logger.info('test3')
             return redirect(url_for('helper.jw_wechat_login', openid=openid))
-
 
         data = {
             'userName': user.user_number,
@@ -290,18 +286,19 @@ def get_wechat_cal_start():
             else:
                 return redirect(url_for('helper.jw_wechat_login', type=1))
 
+
 @helper.route('/wechat/timetable')
 def get_wechat_timetable_start():
     openid = request.args.get('openid')
-    week_now = datetime.datetime.now().isocalendar()[1]-6
-    ##当前是第几周
+    week_now = datetime.datetime.now().isocalendar()[1] - current_app.config.get("STRAT_WEEK", 6)
+    # 当前是第几周
 
-    current_app.logger.info('现在是第%d周'%week_now)
+    current_app.logger.info("week_now is %d" % week_now)
     # week_now = 1
     if not openid:
         current_app.logger.info('test1')
-        return redirect(url_for('helper.timetable',week=week_now))
-        ##当前周
+        return redirect(url_for('helper.timetable', week=week_now))
+        # 当前周
     else:
         user = User.query.filter_by(wechat_id=openid).first()
         if user is None or user.wechat_id is None:
@@ -332,11 +329,11 @@ def get_wechat_timetable_start():
             user.spd.site = 1
             login_res = user.spd.login(login_data=data)
             if login_res != 'success':
+                print(login_res)
                 flash(login_res)
-                sleep(2)
 
-            #     return redirect(url_for('helper.jw_wechat_login', type=1, openid=openid, next=url_for('helper.get_wechat_timetable_start')))
-
+            # return redirect(url_for('helper.jw_wechat_login', type=1, openid=openid,
+            # next=url_for('helper.get_wechat_timetable_start')))
 
         return redirect(url_for('helper.timetable', week=week_now))
 
@@ -349,11 +346,13 @@ def wechat_cal_click():
         return redirect(url_for('helper.get_wechat_cal_start'))
     else:
         current_app.logger.info(current_user.is_authenticated)
-        req_url = 'https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code'%(current_app.config['APP_ID'], current_app.config['APP_SECRET'], code)
+        req_url = 'https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code' % (
+            current_app.config['APP_ID'], current_app.config['APP_SECRET'], code)
         res = requests.get(req_url).content
-        res=res.decode()
+        res = res.decode()
         openid = json.loads(res).get('openid')
         return redirect(url_for('helper.get_wechat_cal_start', openid=openid))
+
 
 @helper.route('/wechat/grade_click')
 def wechat_grade_click():
@@ -363,11 +362,13 @@ def wechat_grade_click():
         return redirect(url_for('helper.get_wechat_grade_start'))
     else:
         current_app.logger.info(current_user.is_authenticated)
-        req_url = 'https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code'%(current_app.config['APP_ID'], current_app.config['APP_SECRET'], code)
+        req_url = 'https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code' % (
+            current_app.config['APP_ID'], current_app.config['APP_SECRET'], code)
         res = requests.get(req_url).content
-        res=res.decode()
+        res = res.decode()
         openid = json.loads(res).get('openid')
         return redirect(url_for('helper.get_wechat_grade_start', openid=openid))
+
 
 @helper.route('/wechat/timetable_click')
 def wechat_timetable_click():
@@ -377,11 +378,13 @@ def wechat_timetable_click():
         return redirect(url_for('helper.get_wechat_timetable_start'))
     else:
         current_app.logger.info(current_user.is_authenticated)
-        req_url = 'https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code'%(current_app.config['APP_ID'], current_app.config['APP_SECRET'], code)
+        req_url = 'https://api.weixin.qq.com/sns/oauth2/access_token?appid=%s&secret=%s&code=%s&grant_type=authorization_code' % (
+            current_app.config['APP_ID'], current_app.config['APP_SECRET'], code)
         res = requests.get(req_url).content
-        res=res.decode()
+        res = res.decode()
         openid = json.loads(res).get('openid')
         return redirect(url_for('helper.get_wechat_timetable_start', openid=openid))
+
 
 @helper.route('/timetable')
 @jw_login_required
@@ -396,7 +399,7 @@ def timetable(week=1):
     if not current_user.remember_me:
         res = current_user.spd.get_course()
         current_app.logger.info(res)
-        if res ==[]:
+        if res == []:
             if current_user.wechat_id:
                 return redirect(url_for('helper.jw_wechat_login', openid=current_user.wechat_id, next=url_for('helper.timetable', week=week)))
             else:
@@ -407,7 +410,6 @@ def timetable(week=1):
             res = current_user.spd.get_course()
             if res == []:
                 flash('获取课程失败')
-                sleep(2)
                 return redirect(url_for('helper.jw_wechat_login', openid=current_user.wechat_id, next=url_for('helper.get_wechat_timetable_start')))
             current_user.save_courses_into_database(res, stu=current_user._get_current_object())
     # res = current_user.spd.get_course()
@@ -423,8 +425,9 @@ def timetable(week=1):
     for r in res:
         r[2] = r[2].replace('\n', '<br>')
     color_list = ['#29B6F6', '#9CCC65', '#EC407A', '#FFA726', '#AB47BC', '#FF7043',
-     '#7E57C2', '#26C6DA', '#66BB6A', '#8D6E63', '#42A5F5', '#BDBDBD', '#5C6BC0', '#26A69A', '#ef5350', '#D4E157']
+                  '#7E57C2', '#26C6DA', '#66BB6A', '#8D6E63', '#42A5F5', '#BDBDBD', '#5C6BC0', '#26A69A', '#ef5350', '#D4E157']
     return render_template('helper/course.html', courses=courses, week_now=week, color_list=color_list, msg=res, len=len, courses_except=courses_except)
+
 
 @helper.route('/suggestion', methods=['GET', 'POST'])
 def suggest():
@@ -434,7 +437,6 @@ def suggest():
         openid = request.args.get('openid')
         if not openid:
             openid = 'Someone'
-        send_email(current_app.config['SEND_MAIL_TO'], 'New suggestion', 'mail/suggestion', wechat_id=openid, content=content)
+        send_email_by_suggestion('mail/suggestion', wechat_id=openid, content=content)
         flash('已收到您的反馈！')
     return render_template('helper/suggestion.html', form=form)
-

--- a/app/main/state.py
+++ b/app/main/state.py
@@ -1,6 +1,10 @@
-from .. import redis
-from ..models import User, AESCipher
+import datetime
+
 from flask import current_app
+
+from .. import redis
+from ..models import AESCipher, User
+
 
 def set_user_state(openid, state):
     """设置用户状态"""
@@ -27,6 +31,7 @@ def get_user_last_interact_time(openid):
     else:
         return 0
 
+
 def jw_delete(id):
     user = User.query.filter_by(wechat_id=id).first()
     if user is None or user.password is None:
@@ -35,6 +40,7 @@ def jw_delete(id):
         user.delete_password()
         msg = '取消绑定成功'
     return msg
+
 
 def courses_fresh(id):
     user = User.query.filter_by(wechat_id=id).first()
@@ -59,7 +65,7 @@ def courses_fresh(id):
                 msg = '登陆教务系统失败'
                 return msg
         res = user.spd.get_course()
-        if res ==[]:
+        if res == []:
             msg = '获取课程失败'
             return msg
         user.save_courses_into_database(res, stu=user)

--- a/app/main/views.py
+++ b/app/main/views.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from flask import render_template, request, make_response, current_app, redirect, url_for, flash
 from flask_login import login_user
 from . import main
@@ -9,15 +10,17 @@ import os
 # from ..helper.forms import wechat_JWLoginForm
 # from ..helper.spider import jw_spider
 
+
 @main.route('/')
 def index():
     return render_template('hello.html')
 
-@main.route('/wechat', methods = ['GET', 'POST'] )
+
+@main.route('/wechat', methods=['GET', 'POST'])
 def wechat_auth():
     wechat = init_wechat_sdk()
     if request.method == 'GET':
-        token = 'tokenOf2017NJUHelper1s'
+        token = current_app.config['TOKEN']
         query = request.args
         signature = query.get('signature', '')
         timestamp = query.get('timestamp', '')
@@ -35,6 +38,7 @@ def wechat_auth():
         timestamp = query.get('timestamp', '')
         nonce = query.get('nonce', '')
         return wechat_response(request.data, msg_signature=signature, timestamp=timestamp, nonce=nonce)
+
 
 # @main.route('/<path>')
 # def today(path):
@@ -124,4 +128,5 @@ def wechat_auth():
 #             return redirect(request.args.get('next') or url_for('helper.get_grade_start'))
 #         else:
 #             flash(login_res)
-#     return render_template('helper/login.html', form=form, message=current_app.config['REMEMBER_PASSWORD_MESSAGE'])
+# return render_template('helper/login.html', form=form,
+# message=current_app.config['REMEMBER_PASSWORD_MESSAGE'])

--- a/app/models.py
+++ b/app/models.py
@@ -5,7 +5,7 @@ from Crypto.Cipher import AES
 from flask_login import UserMixin
 
 from .spider import jw_spider
-from . import db , login_manager
+from . import db, login_manager
 
 
 class User(UserMixin, db.Model):
@@ -22,7 +22,7 @@ class User(UserMixin, db.Model):
     # password_hash = db.Column(db.String(128))
     password = db.Column(db.String(64))
     name = db.Column(db.String(64))
-    ###需要补全，密码要加密
+    # 需要补全，密码要加密
     spd = db.Column(db.PickleType)
     remember_me = db.Column(db.BOOLEAN)
     # spd = jw_spider()
@@ -33,8 +33,8 @@ class User(UserMixin, db.Model):
     courses = db.relationship('Course', backref='stu', lazy='dynamic')
 
     def delete_password(self):
-        self.user_number=None
-        self.password=None
+        self.user_number = None
+        self.password = None
         self.remember_me = False
 
     def get_courses_from_database(self):
@@ -59,11 +59,12 @@ class User(UserMixin, db.Model):
                 db.session.delete(t)
 
         for c in courses:
-            tt = Course(stu=stu, name=c[0], teacher=c[1], place_time=c[2], course_num=c[3], type=c[4], campus=c[5])
+            tt = Course(stu=stu, name=c[0], teacher=c[1], place_time=c[2],
+                        course_num=c[3], type=c[4], campus=c[5])
             db.session.add(tt)
         db.session.commit()
 
-    #暂时用不到
+    # 暂时用不到
     # @property
     # def password(self):
     #     raise AttributeError('password is not a readable attribute')
@@ -76,9 +77,11 @@ class User(UserMixin, db.Model):
     #     return check_password_hash(self.password_hash, password)
     ###
 
+
 @login_manager.user_loader
 def load_user(id):
     return User.query.get(int(id))
+
 
 class Grade(db.Model):
     __tablename__ = 'grades'
@@ -91,6 +94,7 @@ class Grade(db.Model):
     score = db.Column(db.Integer)
     remark = db.Column(db.String(64))
     stu_id = db.Column(db.Integer, db.ForeignKey('users.id'))
+
 
 class Course(db.Model):
     __tablename__ = 'courses'
@@ -106,7 +110,6 @@ class Course(db.Model):
 
 
 class AESCipher():
-
     """
     加密解密方法
     http://stackoverflow.com/questions/12524994

--- a/app/spider.py
+++ b/app/spider.py
@@ -1,20 +1,20 @@
-import requests, re
+import requests
+import re
 from requests.structures import CaseInsensitiveDict
 from bs4 import BeautifulSoup
 from flask import current_app, abort
 
 
-
 class jw_spider:
     def __init__(self):
-        self.site=0
+        self.site = 0
         self.header = {
             'User-Agent': 'Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 Safari/537.36'}
         self.total_grade_all = 0
         self.total_weight_all = 0
-        self.age=16
+        self.age = 16
         self.jws = requests.Session()
-        self.base_url=''
+        self.base_url = ''
 
     def set_age(self, age):
         self.age = age
@@ -104,7 +104,7 @@ class jw_spider:
         # self.total_weight_all += total_weight
         # gpa = total_grade / total_weight / 20
         # print('第%d学期全部课程学分绩为：%f\n' % (term, gpa))
-    ###need to be deleted
+    # need to be deleted
     def alignment(self, str1, space, align='left'):
         length = len(str1.encode('gb2312'))
         space = space - length if space >= length else 0
@@ -134,16 +134,17 @@ class jw_spider:
 
             for j2 in range(len(tds)):
                 # tds[j2] = tds[j2].get_text().strip(' \t')
-                if j2==5:
-                    tds[j2] = BeautifulSoup(tds[j2].encode('utf-8').decode('utf-8').replace('<br/>', '\n'), 'lxml')
+                if j2 == 5:
+                    tds[j2] = BeautifulSoup(tds[j2].encode(
+                        'utf-8').decode('utf-8').replace('<br/>', '\n'), 'lxml')
                 tds[j2] = tds[j2].get_text().strip()
 
             temp.append(str(tds[2]))
             temp.append(str(tds[4]))
             temp.append(str(tds[5]))
-            temp.append(str(tds[0]))#编号
-            temp.append(str(tds[7]))#类型
-            temp.append(str(tds[3]))#校区
+            temp.append(str(tds[0]))  # 编号
+            temp.append(str(tds[7]))  # 类型
+            temp.append(str(tds[3]))  # 校区
             courses.append(temp)
             # print(tds[5])
         return courses
@@ -155,7 +156,7 @@ class jw_spider:
         end = 19
         res = []
         res_except = []
-        dict = {u'一':1, u'二':2, u'三':3, u'四':4, u'五':5, u'六':6, u'日':7}
+        dict = {u'一': 1, u'二': 2, u'三': 3, u'四': 4, u'五': 5, u'六': 6, u'日': 7}
         for c4 in c3:
             # print(c4)
             try:
@@ -165,7 +166,7 @@ class jw_spider:
                     week.append(int(re.sub(r'第(\d+)周 ', r'\1', rr1)))
                 r2 = re.findall(r'\d+-\d+周', c4)
                 for rr2 in r2:
-                    for i in range(int(re.sub(r'(\d+)-(\d+)周', r'\1', rr2)), int(re.sub(r'(\d+)-(\d+)周', r'\2', rr2))+1):
+                    for i in range(int(re.sub(r'(\d+)-(\d+)周', r'\1', rr2)), int(re.sub(r'(\d+)-(\d+)周', r'\2', rr2)) + 1):
                         week.append(i)
                 r3 = re.findall(r'从第\d+周开始:.周 ', c4)
                 for rr3 in r3:
@@ -177,7 +178,7 @@ class jw_spider:
                     else:
                         mod = -1
                     for i in range(int(re.sub(r'从第(\d+)周开始:.周 ', r'\1', rr3)), end):
-                        if i%2 == mod:
+                        if i % 2 == mod:
                             week.append(i)
                 r4 = re.findall(r' .周', c4)
                 # print(r4)
@@ -191,10 +192,11 @@ class jw_spider:
                     else:
                         mod = -1
                     for i in range(1, end):
-                        if i%2 == mod:
+                        if i % 2 == mod:
                             week.append(i)
                 day = dict[c4[1]]
-                jieshu = [int(re.sub(r'[^\d]+第(\d+)-(\d+)节.+', r'\1', c4)), int(re.sub(r'[^\d]+第(\d+)-(\d+)节.+', r'\2', c4))]
+                jieshu = [int(re.sub(r'[^\d]+第(\d+)-(\d+)节.+', r'\1', c4)),
+                          int(re.sub(r'[^\d]+第(\d+)-(\d+)节.+', r'\2', c4))]
                 c5 = c4.split('周')
                 jiaoshi = c5[len(c5) - 1].strip()
                 res.append([week, day, jieshu, jiaoshi])
@@ -222,17 +224,17 @@ class jw_spider:
             for c in course[0]:
                 if week in c[0]:
                     # print(courses)
-                    for i in range(c[2][0], c[2][1]+1):
+                    for i in range(c[2][0], c[2][1] + 1):
                         # print(courses[c[1]-1][i-1][1])
-                        courses[c[1]-1][i-1][1].append(index)
+                        courses[c[1] - 1][i - 1][1].append(index)
 
                     #     courses[c[1]-1][i-1][2] = 'normal'
                     # courses[c[1]-1][c[2][0]-1][2] = 'start'
                     if len(courses[c[1] - 1][c[2][0] - 1][1]) == 1:
-                        courses[c[1]-1][c[2][0]-1][0] = t[0]
+                        courses[c[1] - 1][c[2][0] - 1][0] = t[0]
                     if (c[2][1] > c[2][0]) and len(courses[c[1] - 1][c[2][0]][1]) == 1:
-                        courses[c[1]-1][c[2][0]][0] = c[3]
-                    if (c[2][1] > c[2][0]+1) and len(courses[c[1] - 1][c[2][0]+1][1]) == 1:
-                        courses[c[1]-1][c[2][0]+1][0] = t[1]
+                        courses[c[1] - 1][c[2][0]][0] = c[3]
+                    if (c[2][1] > c[2][0] + 1) and len(courses[c[1] - 1][c[2][0] + 1][1]) == 1:
+                        courses[c[1] - 1][c[2][0] + 1][0] = t[1]
             index += 1
         return [courses, courses_except]

--- a/manage.py
+++ b/manage.py
@@ -1,40 +1,26 @@
 #!/usr/bin/env python
 import os
-from app import create_app, db
-# from app.models import User, Follow, Role, Permission, Post, Comment
-#######
+from app import create_app, db, make_celery
 from flask_script import Manager, Shell
 from flask_migrate import Migrate, MigrateCommand
-# from flask_login import login_manager
-# from app.models import User
+
 
 app = create_app(os.getenv('FLASK_CONFIG') or 'default')
 # app = create_app('production')
 manager = Manager(app)
 migrate = Migrate(app, db)
 
+celery = make_celery(app)
+from tasks import *
+
 
 def make_shell_context():
-    # return dict(app=app, db=db, User=User, Follow=Follow, Role=Role,
-    #             Permission=Permission, Post=Post, Comment=Comment)
-    #########
     return dict(app=app, db=db)
+
 
 manager.add_command("shell", Shell(make_context=make_shell_context))
 manager.add_command('db', MigrateCommand)
 
 
-# @manager.command
-# def test():
-#     """Run the unit tests."""
-#     import unittest
-#     tests = unittest.TestLoader().discover('tests')
-#     unittest.TextTestRunner(verbosity=2).run(tests)
-
-
 if __name__ == '__main__':
     manager.run()
-
-# @login_manager.user_loader
-# def load_user(id):
-#     return User.query.get(int(id))

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,272 @@
+# coding: utf-8
+import os
+import json
+import datetime
+import requests
+from flask import current_app
+from wechat_sdk.exceptions import OfficialAPIError
+
+from app import redis
+from app.main.wechat import init_wechat_sdk
+from app.models import User
+from manage import celery
+
+
+@celery.task(name="send_timetable")
+def send_timetable():
+    if has_disable_send_timetable():  # 可以通过配置文件来禁用课表通知
+        current_app.logger.info("has disable send timetable!")
+        return
+
+    wechat = init_wechat_sdk()
+    template_id = current_app.config.get("SEND_TIMETABLE_TEMPLATE_ID")
+
+    cur_week = get_cur_week()
+    cur_day = get_cur_day()
+
+    users = redis.smembers("subscribe_timetable")
+
+    if users:  # 如果有人订阅了成绩通知才去获取天气信息
+        weather = get_weather_info()
+
+    for openid in users:
+        user = User.query.filter_by(wechat_id=openid).first()
+        if not user or not user.password:
+            redis.srem(openid, 1)
+            continue
+
+        courses = get_today_courses(user, cur_day, cur_week)
+        if not courses:
+            continue
+
+        msg_data = get_msg_data(courses)
+
+        if weather:
+            msg_data['head']['value'] += u'\n今日天气：' + weather
+
+        url = current_app.config.get("SITE_URL") + "/timetable/" + str(cur_week)
+        try:
+            wechat.send_template_message(openid.decode("ascii"), template_id,
+                                         msg_data, url=url)
+        except OfficialAPIError as e:
+            current_app.logger.error("OfficialAPIError: " + str(e.errcode) + ": " + e.errmsg)
+
+    return len(users)
+
+
+def has_disable_send_timetable():
+    if os.path.exists("config.json"):
+        with open("config.json") as f:
+            conf = json.load(f)
+            return conf.get("disable_send_timetable", False)
+    return False
+
+
+def get_cur_day():
+    """
+    根据配置文件以及当前日期来判断上哪一天的课程
+    """
+    day_now = datetime.datetime.now().isocalendar()[2] - 1
+    if os.path.exists("config.json"):
+        with open("config.json") as f:
+            conf = json.load(f)
+            day_now = conf.get("day_now", day_now)
+
+    return day_now
+
+
+def get_cur_week():
+    """
+    根据配置文件以及当前日期来判断上哪一周的课程
+    """
+    week_now = datetime.datetime.now().isocalendar()[1] - current_app.config.get("STRAT_WEEK", 6)
+    if os.path.exists("config.json"):
+        with open("config.json") as f:
+            conf = json.load(f)
+
+            day_now = conf.get("week_now", day_now)
+
+    return week_now
+
+
+def get_today_courses(user, day_now, week_now):
+    res = user.get_courses_from_database()
+    if not res:
+        res = user.spd.get_course()
+    if not res:
+        return
+    else:
+        # courses_raw 是一天内所有课程的原始数据
+        courses_raw = user.spd.create_courses(week=week_now, course_result=res)[0][day_now]
+        courses = {}
+        for index, item in enumerate(courses_raw):
+            if not item[0] or not item[1]:  # 没有课
+                continue
+            course_index = item[1][0]
+
+            if course_index not in courses:
+                courses[course_index] = [index + 1, item[0], 0]
+            else:
+                courses[course_index][2] += 1
+                if not courses[course_index][1].endswith(" "):  # 只保留课程名+上课教室
+                    courses[course_index][1] += (" " + item[0] + " ")
+            # courses的一项：<课程序号, [课程时间，课程名+上课教室, 课程时长]>
+
+        return courses
+
+
+def get_msg_data(courses):
+    data = {
+        "head": {"value": "早上好！", "color": "#000000"},
+        "morning": {"value": "", "color": "#173177"},
+        "afternoon": {"value": "", "color": "#173177"},
+        "night": {"value": "", "color": "#173177"},
+        "tail": {"value": "再见！", "color": "#000000"}
+    }
+
+    # 课程信息填充到data里面
+    for one_course in courses.values():
+        course_time = one_course[0]
+        course_info = one_course[1] + str(one_course[0]) + "-" + str(one_course[2] + one_course[0]) + "节\t"
+        # course_info: 课程名 上课教室 开始节数-结束节数
+
+        if course_time <= 4:
+            data['morning']['value'] += course_info
+        elif course_time <= 8:
+            data['afternoon']['value'] += course_info
+        else:
+            data['night']['value'] += course_info
+
+    # 处理没课的时间段
+    for key in list(data.keys())[1:-1]:  # 只考虑中间三条信息
+        if not data[key]["value"]:
+            data[key]['value'] = "没有."
+        else:
+            data[key]['value'] = data[key]['value'].strip() + '.'
+
+    return data
+
+
+def get_weather_info():
+    # api信息： https://www.nowapi.com/api/weather.future
+    now = datetime.datetime.now().strftime("%Y-%m-%d")
+    appkey = "25438"  # API
+    sign = "89515add40ab3eb11550e099d7e234e8"
+    weather_url = "http://api.k780.com/?app=weather.future&weaid=nanjing&appkey={0}&sign={1}&format=json".format(
+        appkey, sign)
+    aqi_url = "http://api.k780.com/?app=weather.pm25&weaid=nanjing&appkey={0}&sign={1}&format=json".format(
+        appkey, sign)
+    result = None
+
+    try:
+        rsp = requests.get(weather_url)
+        text = rsp.json()
+        w = text['result'][0]  # 今日天气信息
+        rsp = requests.get(aqi_url)
+        text = rsp.json()
+        a = text['result']
+
+        text = w['weather'] + "，"
+        temperature = w['temp_low'] + u"-" + w['temp_high'] + "℃，"
+        wind = w["wind"] + w['winp'] + "。\n"
+
+        aqi = u"空气质量：" + a['aqi_levnm'] + "，AQI指数为" + a['aqi']
+
+        result = text + temperature + wind + aqi + "。"
+    except Exception as e:
+        current_app.logger.error(e)
+    finally:
+        return result
+
+
+@celery.task(name="send_grade")
+def send_grade():
+    if has_disable_send_grade():  # 可以通过配置文件来关掉成绩通知
+        current_app.logger.info("has disable send grade!")
+        return 0
+
+    wechat = init_wechat_sdk()
+    template_id = current_app.config.get("SEND_GRADE_TEMPLATE_ID")
+    users = redis.hgetall("subscribe_grade")
+
+    for openid, info in users.items():
+        user = User.query.filter_by(wechat_id=openid).first()
+        if not user or not user.password:
+            redis.hdel("subscribe_grade", openid)
+            continue
+
+        info = info.decode('utf-8').split()  # info的格式：cur_term 已有成绩的课程名+
+        cur_term = int(info[0]) - 1  # 当前学期
+        old_grades = info[1:]
+
+        grades = get_grade(user, old_grades, cur_term)
+
+        # 如果没有新成绩
+        if not grades:
+            continue
+
+        msg_data = get_grade_msg(grades)
+
+        save_new_grade(info, openid, grades)
+
+        url = current_app.config.get("SITE_URL") + "/grades/" + str(cur_term)
+
+        try:
+            wechat.send_template_message(openid.decode("ascii"), template_id,
+                                         msg_data, url=url)
+        except OfficialAPIError as e:
+            current_app.logger.error("OfficialAPIError: " + str(e.errcode) + ": " + e.errmsg)
+
+    return len(users)
+
+
+def has_disable_send_grade():
+    if os.path.exists("config.json"):
+        with open("config.json") as f:
+            conf = json.load(f)
+            return conf.get("disable_send_grade", False)
+    return False
+
+
+def get_grade(user, old_grades, cur_term):
+    """
+    从教务网获取当前成绩并返回有新成绩的课程
+    """
+    result = None
+    try:
+        grades = user.spd.get_grade(age=user.spd.age, term=cur_term)
+        result = []
+
+        for item in grades:
+            if item[0] not in old_grades:
+                result.append(item)
+
+    except Exception as e:
+        current_app.logger.error(e)
+    finally:
+        return result
+
+
+def get_grade_msg(grades):
+    data = {
+        "head": {"value": "", "color": "#000000"},
+        "msg": {"value": "", "color": "#173177"},
+        "tail": {"value": "", "color": "#000000"}
+    }
+    values = []
+    for grade in grades:
+        values.append(grade[0] + "：" + grade[2] + "学分，成绩：" + grade[3] + "。")
+
+    data['msg']['value'] = "\n".join(values)
+
+    return data
+
+
+def save_new_grade(info, openid, new_grades):
+    """
+    将现在所有有成绩的课程都记录下来
+    """
+    for item in new_grades:
+        info.append(item[0])
+    info_str = " ".join(info)
+    redis.hset("subscribe_grade", openid, info_str)


### PR DESCRIPTION
每日课程订阅、新成绩订阅功能：
- 使用celery，相关配置在config.py
- 相关代码在tasks.py中，订阅/退订在app/main/wechat.py中
- 需要运行celery：celery -A manage.celery worker --beat -l info
- 可以通过同一目录下的config.json对功能进行控制

新的配置项：
- celery 相关的配置，包括celery设置以及celery的定时任务
- START_WEEK：本学期第一周对应本年度的周数
- 微信模板消息的ID：SEND_TIMETABLE_TEMPLATE_ID 和 SEND_GRADE_TEMPLATE_ID
- SITE_URL： 部署本应用的网址，便于其他人部署

修改部分细节代码：
- 修改发送邮件的逻辑，使用celery进行异步任务而不是多线程
- 删除部分无用注释
- 修改部分代码风格
- 增加异常拦截，在app/main/wechat.py，发生异常后给管理员发送邮件

微信模板消息示例：
- 课表信息：{{ head.DATA }} \n 上午课程：{{ morning.DATA }} \n 下午课程：{{ afternoon.DATA }} \n 晚上课程: {{ night.DATA }} \n {{ tail.DATA }}
- 成绩信息：{{ head.DATA }} \n {{ msg.DATA }} \n {{ tail.DATA }}
- 注：把对应的模板ID配置到config.py中，\n替换为真实的换行
